### PR TITLE
Fix/staking cleanup change

### DIFF
--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -368,6 +368,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @param token Token that will be staked 
      */
     function _stake(uint256 odyssey_id, uint256 amount, Token token) private {
+        require(amount > 0, "Amount cannot be 0");
         if(token == Token.DAD) {
             require(IERC20(dad_token).transferFrom(payable(msg.sender), address(this), amount));
         } else {

--- a/contracts/staking/Staking.sol
+++ b/contracts/staking/Staking.sol
@@ -41,7 +41,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @dev Holds the relation Staker -> Odyssey info
      */
     struct StakingAt {
-        bytes16 odyssey_id;
+        uint256 odyssey_id;
         uint256 total_amount;
         uint256 dad_amount;
         uint256 mom_amount;
@@ -53,7 +53,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @dev Holds the Odyssey info
      */
     struct Odyssey {
-        bytes16 odyssey_id;
+        uint256 odyssey_id;
         uint256 total_staked_into;
         uint256 total_stakers;
     }
@@ -116,7 +116,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
     /**
      * @notice Mapping of Odysseys by its ID's
      */
-    mapping (bytes16 => Odyssey) public odysseys;
+    mapping (uint256 => Odyssey) public odysseys;
 
     /**
      * @notice Mapping the values of each Odyssey that the user is staking
@@ -127,18 +127,18 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
     /**
      * @notice Mapping the indexes of the `StakingAt` list of the user
      */
-    mapping (address => mapping(bytes16 => uint256)) public staking_at_indexes;
+    mapping (address => mapping(uint256 => uint256)) public staking_at_indexes;
 
     /**
      * @notice Mapping the values of each Staker that the Odyssey is being staked by
      * Should match respective StakingAt
      */
-    mapping (bytes16 => StakedBy[]) public staked_by;
+    mapping (uint256 => StakedBy[]) public staked_by;
 
     /**
      * @notice Mapping the indexes of the `StakedBy` list of the Odyssey
      */
-    mapping (bytes16 => mapping(address => uint256)) public staked_by_indexes;
+    mapping (uint256 => mapping(address => uint256)) public staked_by_indexes;
 
     /**
      * @notice Mapping the unstake list of the user address
@@ -164,8 +164,8 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @param total_staked_to Total amount of tokens staked on `odyssey_to`
      */
     event Restake(address user,
-                  bytes16 odyssey_from,
-                  bytes16 odyssey_to,
+                  uint256 odyssey_from,
+                  uint256 odyssey_to,
                   uint256 amount,
                   Token token,
                   uint256 total_staked_from,
@@ -194,7 +194,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @param token Token used (MOM or DAD) 
      * @param total_staked Total being staked by the user on the Odyssey
      */
-    event Stake(address user, bytes16 odyssey, uint256 amount_staked, Token token, uint256 total_staked);
+    event Stake(address user, uint256 odyssey, uint256 amount_staked, Token token, uint256 total_staked);
 
     /**
      * 
@@ -204,12 +204,12 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @param token Token used (MOM or DAD)
      * @param total_staked Total remained staked by the user on that Odyssey
      */
-    event Unstake(address user, bytes16 odyssey, uint256 amount_unstaked, Token token, uint256 total_staked);
+    event Unstake(address user, uint256 odyssey, uint256 amount_unstaked, Token token, uint256 total_staked);
 
     /**
      * @notice list of staked odysseys
      */
-    bytes16[] public staked_odysseys;
+    uint256[] public staked_odysseys;
 
     /**
      * @dev Initializer of the contract, is called when deploying
@@ -286,7 +286,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
     /**
      * @dev Returns the list of staked Odysseys
      */
-    function get_staked_odysseys() external view returns(bytes16[] memory) {
+    function get_staked_odysseys() external view returns(uint256[] memory) {
         return staked_odysseys;
     }
 
@@ -302,7 +302,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @dev Returns the list of Stakers that are staking at the Odyssey
      * @param odyssey the Odyssey ID
      */
-    function get_staked_by(bytes16 odyssey) external view returns(StakedBy[] memory) {
+    function get_staked_by(uint256 odyssey) external view returns(StakedBy[] memory) {
         return staked_by[odyssey];
     }
 
@@ -312,7 +312,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @param amount Amount to be staked in the Odyssey
      * @param token Token that will be staked
      */
-    function stake(bytes16 odyssey_id, uint256 amount, Token token) public payable {
+    function stake(uint256 odyssey_id, uint256 amount, Token token) public payable {
         _stake(odyssey_id, amount, token);
     }
 
@@ -321,7 +321,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @param odyssey_id Odyssey id that will be unstaked
      * @param token token to be unstaked
      */
-    function unstake(bytes16 odyssey_id, Token token) public {
+    function unstake(uint256 odyssey_id, Token token) public {
         _unstake(odyssey_id, token);
     }
     
@@ -332,7 +332,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @param amount Amount to be restaked
      * @param token Token that will be restaked
      */
-    function restake(bytes16 from_odyssey_id, bytes16 to_odyssey_id, uint256 amount, Token token) public {
+    function restake(uint256 from_odyssey_id, uint256 to_odyssey_id, uint256 amount, Token token) public {
         _restake(from_odyssey_id, to_odyssey_id, amount, token);
     }
 
@@ -356,7 +356,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @param amount Amount to be staked in the Odyssey
      * @param token Token that will be staked 
      */
-    function _stake(bytes16 odyssey_id, uint256 amount, Token token) private {
+    function _stake(uint256 odyssey_id, uint256 amount, Token token) private {
         if(token == Token.DAD) {
             require(IERC20(dad_token).transferFrom(payable(msg.sender), address(this), amount));
         } else {
@@ -448,7 +448,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @param odyssey_id Odyssey id that will be unstaked
      * @param token token to be unstaked
      */
-    function _unstake(bytes16 odyssey_id, Token token) private {
+    function _unstake(uint256 odyssey_id, Token token) private {
         Staker storage staker = stakers[msg.sender];
         Odyssey storage odyssey = odysseys[odyssey_id];
 
@@ -517,7 +517,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @param amount Amount to be restaked
      * @param token Token that will be restaked
      */
-    function _restake(bytes16 from_odyssey_id, bytes16 to_odyssey_id, uint256 amount, Token token) private {
+    function _restake(uint256 from_odyssey_id, uint256 to_odyssey_id, uint256 amount, Token token) private {
         require(amount > 0, "Amount cannot be 0");
         require(stakers[msg.sender].user != address(0), "Not a staker");
         require(staking_at_indexes[msg.sender][from_odyssey_id] > 0, "Not staking in that Odyssey");
@@ -664,7 +664,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @param odyssey_id Odyssey id
      * @param staker address of the user
      */
-    function remove_staking_at(bytes16 odyssey_id, address staker) private {
+    function remove_staking_at(uint256 odyssey_id, address staker) private {
         // Only staking in one Odyssey
         if(staking_at[staker].length == 2) {
             delete staking_at[staker];
@@ -682,7 +682,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @param odyssey_id Odyssey id
      * @param staker address of the user
      */
-    function remove_staked_by(bytes16 odyssey_id, address staker) private {
+    function remove_staked_by(uint256 odyssey_id, address staker) private {
         if(staked_by[odyssey_id].length == 2) {
             delete staked_by[odyssey_id];
             staked_by_indexes[odyssey_id][staker] = 0;
@@ -699,7 +699,7 @@ contract Staking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
      * @param odyssey_id Odyssey id
      * @param amount amount to be decreased from total_staked_into
      */
-    function decrease_odyssey_total_stakers(bytes16 odyssey_id, uint256 amount) private {
+    function decrease_odyssey_total_stakers(uint256 odyssey_id, uint256 amount) private {
         odysseys[odyssey_id].total_stakers--;
         odysseys[odyssey_id].total_staked_into -= amount;
     }

--- a/contracts/staking/utils/StakingV2Test.sol
+++ b/contracts/staking/utils/StakingV2Test.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../Staking.sol";
+
+/** 
+* @title Staking Upgrade TEST Contract
+* @author Odyssey
+* @notice contract to test the upgrade functionality for the staking contract
+*/
+contract StakingV2Test is Staking {
+    bool public isUpgraded;
+
+    function reinitialize() public {
+        isUpgraded = true;
+    }
+}

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -6,14 +6,12 @@ async function main() {
 
   const MOMToken = await ethers.getContractFactory("MOMToken");
   const momToken = await MOMToken.deploy(initialSupply);
+  await momToken.deployed();
 
   const DADToken = await ethers.getContractFactory("DADToken");
   const dadToken = await DADToken.deploy();
+  await dadToken.deployed();
   
-  const Staking = await ethers.getContractFactory("Staking");
-  const staking = await upgrades.deployProxy(Staking, [momToken.address, dadToken.address],
-     { initializer: "initialize", kind: "uups"});
-
   const Nft = await ethers.getContractFactory('OdysseyNFT');
   const nft = await Nft.deploy(
     "OdysseyNFT", 
@@ -22,12 +20,15 @@ async function main() {
     150,
     "http://IPFS/url"
   );
-
-
-  await momToken.deployed();
-  await dadToken.deployed();
-  await staking.deployed();
   await nft.deployed();
+  
+  const Staking = await ethers.getContractFactory("Staking");
+  const staking = await upgrades.deployProxy(Staking, [momToken.address, dadToken.address, nft.address],
+     { initializer: "initialize", kind: "uups"});
+  await staking.deployed();
+
+
+
   
   
   

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -27,11 +27,6 @@ async function main() {
      { initializer: "initialize", kind: "uups"});
   await staking.deployed();
 
-
-
-  
-  
-  
   console.log(`MOM Token deployed to ${momToken.address} with Initial Supply of ${initialSupply}`);
   console.log(`DAD Token deployed to ${dadToken.address} with Initial Supply of ${initialSupply}`);
   console.log(`Staking deployed to ${staking.address}`);

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -48,6 +48,24 @@ describe("Staking", function () {
       expect(await staking.dad_token()).to.equal(dadToken.address);
     });
   });
+  
+  describe("Upgrade", function () {
+    it("should set the right token contract addresses on initialize", async function () {
+      const { staking } = await loadFixture(deployStaking);
+      
+      const Stakingv2 = await ethers.getContractFactory("StakingV2Test");
+      await upgrades.upgradeProxy(staking.address, Stakingv2,
+        {
+          call: {fn: 'reinitialize'},
+          kind: "uups"
+        }
+      );
+
+      const stakingv2 = await ethers.getContractAt("StakingV2Test", staking.address)
+      expect(staking.address).to.be.eq(stakingv2.address);
+      expect(await stakingv2.isUpgraded()).to.be.eq(true);
+    });
+  });
 
   describe("Stake", function () {
     it("should revert if user do not have enough MOM balance or doesn't have allowance", async function () {

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -68,6 +68,14 @@ describe("Staking", function () {
   });
 
   describe("Stake", function () {
+    it("should not be able to stake 0 tokens", async function () {
+      const { staking, momToken, addr0 } = await loadFixture(deployStaking);
+      const amount = 0;
+      const odyssey_id = "0xe276ba1dff024fd28fcff53b6d93028a";
+      
+      await expect(staking.connect(addr0).stake(odyssey_id, amount, Token.MOM)).to.be.revertedWith("Amount cannot be 0");
+    });
+
     it("should revert if user do not have enough MOM balance or doesn't have allowance", async function () {
       const { staking, momToken, addr0 } = await loadFixture(deployStaking);
       const amount = 1000;

--- a/test/Staking.ts
+++ b/test/Staking.ts
@@ -7,7 +7,12 @@ import { Token, utils } from "./utils";
 describe("Staking", function () {
   async function deployStaking() {
     const initialSupply = 1000;
-    const [owner, addr0, addr1] = await ethers.getSigners();
+    const [owner, addr0, addr1, addr2] = await ethers.getSigners();
+    const name = 'Odyssey_NFT';
+    const symbol = 'ODS';
+    const maxOdysseySupply = 21000;
+    const maxTokensPerWallet = 150;
+    const URI =  "ipfs://";
 
     const MOMToken = await ethers.getContractFactory("MOMToken");
     const momToken = await MOMToken.deploy(initialSupply);
@@ -15,11 +20,15 @@ describe("Staking", function () {
     const DADToken = await ethers.getContractFactory("DADToken");
     const dadToken = await DADToken.deploy();
 
+    const OdysseyNFT = await ethers.getContractFactory("OdysseyNFT");
+    const odysseyNFT = await OdysseyNFT.deploy(name, symbol, maxOdysseySupply, maxTokensPerWallet, URI);
+
     await momToken.deployed();
     await dadToken.deployed();
+    await odysseyNFT.deployed();
 
     const Staking = await ethers.getContractFactory("Staking");
-    const staking = <Staking> await upgrades.deployProxy(Staking, [momToken.address, dadToken.address], { initializer: 'initialize', kind: 'uups'});
+    const staking = <Staking> await upgrades.deployProxy(Staking, [momToken.address, dadToken.address, odysseyNFT.address], { initializer: 'initialize', kind: 'uups'});
 
     await staking.deployed();
 
@@ -28,7 +37,7 @@ describe("Staking", function () {
     await dadToken.grantRole(dadToken.TRANSFER_ROLE(), staking.address);
     await momToken.grantRole(momToken.MINTER_ROLE(), staking.address);
 
-    return { staking, momToken, dadToken, owner, addr0, addr1 };
+    return { staking, momToken, dadToken, odysseyNFT, owner, addr0, addr1, addr2 };
   }
 
   describe("Initialize", function () {
@@ -41,6 +50,17 @@ describe("Staking", function () {
   });
 
   describe("Stake", function () {
+    it("should revert if user do not have enough MOM balance or doesn't have allowance", async function () {
+      const { staking, momToken, addr0 } = await loadFixture(deployStaking);
+      const amount = 1000;
+      const odyssey_id = "0xe276ba1dff024fd28fcff53b6d93028a";
+      
+      await momToken.mint(addr0.address, amount);
+      await momToken.connect(addr0).approve(staking.address, amount);
+      
+      await expect(staking.connect(addr0).stake(odyssey_id, amount+1, Token.MOM)).to.be.revertedWith("ERC20: insufficient allowance");
+    });
+
     it("should stake MOM and update structures, first time", async function () {
       const { staking, momToken, addr0 } = await loadFixture(deployStaking);
       const amount = 1000;
@@ -94,6 +114,17 @@ describe("Staking", function () {
       await expect(await staking.connect(addr0).stake(odyssey_id, amount, Token.MOM)).to.emit(staking, "Stake").withArgs(addr0.address, odyssey_id, amount, Token.MOM, amount);
       expect(await staking.total_staked()).to.be.eq(amount);
       expect(await momToken.balanceOf(addr0.address)).to.eq(0);
+    });
+
+    it("should revert if user do not have enough DAD balance or doesn't have allowance", async function () {
+      const { staking, dadToken, addr0 } = await loadFixture(deployStaking);
+      const amount = 1000;
+      const odyssey_id = "0xe276ba1dff024fd28fcff53b6d93028a";
+      
+      await dadToken.mint(addr0.address, amount);
+      await dadToken.connect(addr0).approve(staking.address, amount);
+      
+      await expect(staking.connect(addr0).stake(odyssey_id, amount+1, Token.DAD)).to.be.revertedWith("ERC20: insufficient allowance");
     });
 
     it("should stake DAD and update structures, first time", async function () {
@@ -153,6 +184,14 @@ describe("Staking", function () {
   });
 
   describe("Unstake", function () {
+    it("should revert unstake if user is not staking on that Odyssey", async function () {
+      const { staking, addr0 } = await loadFixture(deployStaking);
+      const amount = 1000;
+      const odyssey_id = "0xe276ba1dff024fd28fcff53b6d93028a";
+      
+      await expect(staking.connect(addr0).unstake(odyssey_id, Token.MOM)).to.be.revertedWith("Invalid user or user not staking on that Odyssey");
+    });
+    
     it("should unstake MOM and update structures removing staker and staked_by, only MOM staked", async function () {
       const { staking, momToken, addr0 } = await loadFixture(deployStaking);
       const amount = 1000;
@@ -215,6 +254,32 @@ describe("Staking", function () {
 
       const odyssey = await staking.odysseys(odyssey_one_id);
       expect(odyssey.total_stakers).to.be.eq(0);
+    });
+
+    it("should unstake MOM and update structures removing staker and staked_by, both MOM and DAD staked differently by more than one staker in one Odyssey", async function () {
+      const { staking, momToken, dadToken, addr0, addr1, addr2 } = await loadFixture(deployStaking);
+      const amount = 1000;
+      const odyssey_id = "0xe276ba1dff024fd28fcff53b6d93028a";
+      
+      await momToken.mint(addr0.address, amount);
+      await dadToken.mint(addr1.address, amount);
+      await momToken.mint(addr2.address, amount);
+      await momToken.connect(addr0).approve(staking.address, amount);
+      await dadToken.connect(addr1).approve(staking.address, amount);
+      await momToken.connect(addr2).approve(staking.address, amount);
+      await staking.connect(addr0).stake(odyssey_id, amount, Token.MOM);
+      await staking.connect(addr1).stake(odyssey_id, amount, Token.DAD);
+      await staking.connect(addr2).stake(odyssey_id, amount, Token.MOM);
+
+      expect(await staking.callStatic.total_staked()).to.be.eq(amount*3);
+      await expect(await staking.connect(addr1).unstake(odyssey_id, Token.DAD)).to.emit(staking, "Unstake").withArgs(addr1.address, odyssey_id, amount, Token.DAD, 0);
+      expect(await staking.callStatic.total_staked()).to.be.eq(amount*2);
+      
+      const staker = await staking.callStatic.stakers(addr1.address);
+      expect(staker.user).to.be.eq(ethers.constants.AddressZero);
+
+      const odyssey = await staking.callStatic.odysseys(odyssey_id);
+      expect(odyssey.total_stakers).to.be.eq(2);
     });
 
     it("should revert if there is no tokens to claim", async function () {
@@ -414,7 +479,31 @@ describe("Staking", function () {
     it("should revert when no rewards to be claimed", async function () {
       const { staking, addr0 } = await loadFixture(deployStaking);
 
-      await expect(staking.connect(addr0).claim_rewards()).to.revertedWith("No rewards available");
+      await expect(staking.connect(addr0)["claim_rewards()"]()).to.revertedWith("No rewards available");
+    });
+
+    it("should revert when no Odyssey rewards to be claimed", async function () {
+      const { staking, addr0 } = await loadFixture(deployStaking);
+
+      await expect(staking.connect(addr0)["claim_rewards(uint256)"](1)).to.revertedWith("No rewards available");
+    });
+
+    it("should revert when user is not Odyssey owner", async function () {
+      const { staking, momToken, odysseyNFT, addr0, owner } = await loadFixture(deployStaking);
+      const amount = 1000;
+      const rewards = 50;
+
+      await odysseyNFT.safeMint(owner.address);
+      const odyssey_id = await odysseyNFT.callStatic.currentId();
+
+      await momToken.mint(addr0.address, amount);
+      await momToken.connect(addr0).approve(staking.address, amount);
+      await staking.connect(addr0).stake(odyssey_id, amount, Token.MOM);
+
+      await staking.update_rewards([addr0.address], [rewards], [odyssey_id], [rewards], await time.latest());
+
+      await expect(staking.connect(addr0)["claim_rewards(uint256)"](odyssey_id)).to.be.revertedWith("Not owner of that Odyssey");
+      await expect(await momToken.balanceOf(addr0.address)).to.be.eq(0);
     });
 
     it("should revert when updating rewards timeout", async function () {
@@ -422,36 +511,70 @@ describe("Staking", function () {
       const amount = 1000;
       const timeout = await time.latest() - time.duration.minutes(4);
 
-      await expect(staking.update_rewards([addr0.address], [amount], timeout)).to.revertedWith("Timeout");
+      await expect(staking.update_rewards([addr0.address], [amount], [1], [1], timeout)).to.revertedWith("Timeout");
+    });
+
+    it("should revert when updating rewards receives an empty list in inputs", async function () {
+      const { staking, addr0 } = await loadFixture(deployStaking);
+      const amount = 1000;
+
+      await expect(staking.update_rewards([addr0.address], [amount], [], [1], await time.latest())).to.revertedWith("Invalid Input");
+    });
+
+    it("should revert when updating rewards receives a future timestamp", async function () {
+      const { staking, addr0 } = await loadFixture(deployStaking);
+      const amount = 1000;
+      const timeout = await time.latest() + time.duration.minutes(4);
+
+      await expect(staking.update_rewards([addr0.address], [amount], [1], [1], timeout)).to.revertedWith("Invalid timestamp");
     });
 
     it("should update rewards", async function () {
-      const { staking, addr0 } = await loadFixture(deployStaking);
+      const { staking, momToken, addr0 } = await loadFixture(deployStaking);
       const amount = 1000;
-
-      await expect(staking.update_rewards([addr0.address], [amount], await time.latest())).to.emit(staking, "RewardsUpdated").withArgs(await (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp, await ethers.provider.getBlockNumber());
-    });
-
-    it("should claim rewards when user have only Odyssey rewards", async function () {
-      const { staking, addr0 } = await loadFixture(deployStaking);
-      const amount = 1000;
-      await staking.update_rewards([addr0.address], [amount], await time.latest());
-
-      await expect(await staking.connect(addr0).claim_rewards()).to.emit(staking, "RewardsClaimed").withArgs(addr0.address, amount);
-    });
-
-    it("should claim rewards when user has staking with/without Odyssey rewards", async function () {
-      const { staking, momToken, dadToken, owner, addr0 } = await loadFixture(deployStaking);
-      const amount = 1000;
-      const odyssey_id = "0xe276ba1dff024fd28fcff53b6d93028a";
+      const odyssey_id = 604472133179351442128925n;
 
       await momToken.mint(addr0.address, amount);
       await momToken.connect(addr0).approve(staking.address, amount);
       await staking.connect(addr0).stake(odyssey_id, amount, Token.MOM);
 
-      await staking.update_rewards([addr0.address], [amount], await time.latest());
+      await expect(staking.update_rewards([addr0.address], [amount], [odyssey_id], [amount], await time.latest())).to.emit(staking, "RewardsUpdated").withArgs(await (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp, await ethers.provider.getBlockNumber());
+    });
 
-      await expect(await staking.connect(addr0).claim_rewards()).to.emit(staking, "RewardsClaimed").withArgs(addr0.address, amount);
+    it("should claim odyssey rewards when user is owner and have rewards", async function () {
+      const { staking, momToken, odysseyNFT, addr0 } = await loadFixture(deployStaking);
+      const amount = 1000;
+      const rewards = 50;
+
+      await odysseyNFT.safeMint(addr0.address);
+      const odyssey_id = await odysseyNFT.callStatic.currentId();
+
+      await momToken.mint(addr0.address, amount);
+      await momToken.connect(addr0).approve(staking.address, amount);
+      await staking.connect(addr0).stake(odyssey_id, amount, Token.MOM);
+
+      await staking.update_rewards([addr0.address], [rewards], [odyssey_id], [rewards], await time.latest());
+
+      await expect(await staking.connect(addr0)["claim_rewards(uint256)"](odyssey_id)).to.emit(staking, "OdysseyRewardsClaimed").withArgs(odyssey_id, rewards);
+      await expect(await momToken.balanceOf(addr0.address)).to.be.eq(rewards);
+    });
+
+    it("should claim rewards when user has staking rewards", async function () {
+      const { staking, momToken, odysseyNFT, addr0 } = await loadFixture(deployStaking);
+      const amount = 1000;
+      const rewards = 50;
+
+      await odysseyNFT.safeMint(addr0.address);
+      const odyssey_id = await odysseyNFT.callStatic.currentId();
+
+      await momToken.mint(addr0.address, amount);
+      await momToken.connect(addr0).approve(staking.address, amount);
+      await staking.connect(addr0).stake(odyssey_id, amount, Token.MOM);
+
+      await staking.update_rewards([addr0.address], [rewards], [odyssey_id], [rewards], await time.latest());
+
+      await expect(await staking.connect(addr0)["claim_rewards()"]()).to.emit(staking, "RewardsClaimed").withArgs(addr0.address, rewards);
+      await expect(await momToken.balanceOf(addr0.address)).to.be.eq(rewards);
     });
   });
 
@@ -704,6 +827,65 @@ describe("Staking", function () {
       expect(await staking.connect(addr0).rewards_timeout()).not.eq(0);
       
       await expect(staking.connect(addr0).update_rewards_timeout(minutes)).to.be.revertedWith(utils.rolesRevertString(addr0.address, manager_role));
+    });
+
+    it("should update Odyssey NFT's contract if manager", async function () {
+      const { staking, owner } = await loadFixture(deployStaking);
+
+      expect(await staking.connect(owner).odyssey_nfts()).not.eq(ethers.constants.AddressZero);
+
+      staking.connect(owner).update_odyssey_nfts_contract(ethers.constants.AddressZero)
+      
+      expect(await staking.connect(owner).odyssey_nfts()).eq(ethers.constants.AddressZero);
+    });
+
+    it("should revert update Odyssey NFT's if not manager", async function () {
+      const { staking, addr0 } = await loadFixture(deployStaking);
+      const manager_role = await staking.MANAGER_ROLE();
+      expect(await staking.connect(addr0).odyssey_nfts()).not.eq(ethers.constants.AddressZero);
+
+      await expect(staking.connect(addr0).update_odyssey_nfts_contract(ethers.constants.AddressZero)).to.be.revertedWith(utils.rolesRevertString(addr0.address, manager_role));
+    });
+
+    it("should get staked Odysseys list", async function () {
+      const { staking, momToken, addr0 } = await loadFixture(deployStaking);
+      const amount = 1000;
+      const odyssey_id = "0xe276ba1dff024fd28fcff53b6d93028a";
+
+      let staked_odysseys = await staking.callStatic.get_staked_odysseys();
+
+      expect(staked_odysseys.length).to.be.eq(0);
+
+      
+      await momToken.mint(addr0.address, amount);
+      await momToken.connect(addr0).approve(staking.address, amount);
+
+      await staking.connect(addr0).stake(odyssey_id, amount, Token.MOM)
+
+      staked_odysseys = await staking.callStatic.get_staked_odysseys();
+
+      expect(staked_odysseys.length).to.be.eq(1);
+    });
+
+    it("should get staked_by list", async function () {
+      const { staking, momToken, addr0 } = await loadFixture(deployStaking);
+      const amount = 1000;
+      const odyssey_id = "0xe276ba1dff024fd28fcff53b6d93028a";
+
+      let staked_by = await staking.callStatic.get_staked_by(odyssey_id);
+
+      expect(staked_by.length).to.be.eq(0);
+
+      
+      await momToken.mint(addr0.address, amount);
+      await momToken.connect(addr0).approve(staking.address, amount);
+
+      await staking.connect(addr0).stake(odyssey_id, amount, Token.MOM)
+
+      staked_by = await staking.callStatic.get_staked_by(odyssey_id);
+
+      // Expected 2 because we do not use index 0
+      expect(staked_by.length).to.be.eq(2);
     });
   });
 });


### PR DESCRIPTION
Cleaning up staking contract, plus adding some requested changes:

- Changing ID of `odyssey_id` from `bytes16` to `uint256`.
- Removing the structure `StakingAt` and all related structures, since it will not be needed anymore for reward calculations.
- Update rewards now update the rewards for Odysseys as well. The Odyssey rewards belongs to the Odyssey, not the User. The current User can claim them.
- Test coverage improved, together with contract upgrade test.
- Cannot stake 0 tokens
- Removing unstaked Odysseys from contract

Currently on test in DEV, after it's been tested and approved, the docs will be updated and the PR merged.